### PR TITLE
男女表示をクリックで切り替え可能に

### DIFF
--- a/seigae/src/App.css
+++ b/seigae/src/App.css
@@ -284,7 +284,7 @@ button.danger {
 }
 
 .gender-toggle {
-  min-width: 2.4rem;
+  min-width: 4.9rem;
   padding: 0.35rem 0.55rem;
 }
 

--- a/seigae/src/App.tsx
+++ b/seigae/src/App.tsx
@@ -55,6 +55,11 @@ function formatGenderLabel(gender: PersonDTO['gender']): string {
   return gender === 'female' ? '女' : '男'
 }
 
+function formatGenderToggleText(gender: PersonDTO['gender']): string {
+  // 現在値と次の値を並べて、クリックで切り替わることを明示する。
+  return `${formatGenderLabel(gender)}→${formatGenderLabel(toggleGender(gender))}`
+}
+
 function toSeatKey(raw: string): SeatKey | null {
   if (!/^r\d+c\d+$/.test(raw)) {
     return null
@@ -998,8 +1003,9 @@ export default function App() {
                                 }
                                 onClick={() => void handleToggleGender(person.id)}
                                 aria-label={`${person.name} の性別を切り替え`}
+                                title={`クリックで ${formatGenderLabel(toggleGender(person.gender))} に切り替え`}
                               >
-                                {formatGenderLabel(person.gender)}
+                                {formatGenderToggleText(person.gender)}
                               </button>
                               <button
                                 type="button"


### PR DESCRIPTION
## 変更内容
- メンバー一覧で性別をクリックすると男/女を切り替え可能
- 性別ボタンの表示を「男→女 / 女→男」にして、次の状態がわかるよう改善
- 既存プロジェクトの gender 未設定データは読み込み時に male へ補完

## 動作確認
- npm test
- npm run build
- npm run lint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted gender toggle button width for improved layout presentation.

* **New Features**
  * Gender toggle button now displays current and next gender values with directional arrow notation (e.g., "Male→Female").
  * Added descriptive tooltip explaining the toggle result on button hover.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->