### PR TITLE
座席設定画面の性別トグルをクリック後に無効化

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -115,7 +115,7 @@ export default function App() {
 
   const [singleName, setSingleName] = useState('')
   const [bulkNames, setBulkNames] = useState('')
-  const [genderToggleDisabledByPersonId, setGenderToggleDisabledByPersonId] = useState<Record<string, boolean>>({})
+  const [genderToggleDisabled, setGenderToggleDisabled] = useState(false)
 
   const [fixedPersonIdDraft, setFixedPersonIdDraft] = useState('')
   const [fixedSeatDraft, setFixedSeatDraft] = useState('')
@@ -242,7 +242,7 @@ export default function App() {
 
   useEffect(() => {
     // プロジェクトを切り替えたら、性別トグルの disable 状態を初期化する。
-    setGenderToggleDisabledByPersonId({})
+    setGenderToggleDisabled(false)
   }, [selectedProjectId])
 
   useEffect(() => {
@@ -479,12 +479,11 @@ export default function App() {
 
   const handleToggleGender = useCallback(
     async (personId: string) => {
-      if (!selectedProject || genderToggleDisabledByPersonId[personId]) {
+      if (!selectedProject || genderToggleDisabled) {
         return
       }
 
       clearMessages()
-      setGenderToggleDisabledByPersonId((current) => ({ ...current, [personId]: true }))
       const nextPersons = selectedProject.persons.map((person) => {
         if (person.id !== personId) {
           return person
@@ -495,7 +494,7 @@ export default function App() {
 
       await saveProject({ ...selectedProject, persons: nextPersons })
     },
-    [clearMessages, genderToggleDisabledByPersonId, saveProject, selectedProject],
+    [clearMessages, genderToggleDisabled, saveProject, selectedProject],
   )
 
   const handleDeletePerson = useCallback(
@@ -938,6 +937,9 @@ export default function App() {
                       <button type="button" onClick={() => void handleUpdateLayout()}>
                         レイアウト更新
                       </button>
+                      <button type="button" onClick={() => setGenderToggleDisabled((current) => !current)}>
+                        男女切替: {genderToggleDisabled ? '無効中' : '有効中'}
+                      </button>
                     </div>
                     <p>席をクリックすると無効席を切り替えます。</p>
                     <div
@@ -1009,7 +1011,7 @@ export default function App() {
                                   person.gender === 'female' ? 'gender-toggle is-female' : 'gender-toggle is-male'
                                 }
                                 onClick={() => void handleToggleGender(person.id)}
-                                disabled={Boolean(genderToggleDisabledByPersonId[person.id])}
+                                disabled={genderToggleDisabled}
                                 aria-label={`${person.name} の性別を切り替え`}
                                 title={`クリックで ${formatGenderLabel(toggleGender(person.gender))} に切り替え`}
                               >

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -115,6 +115,7 @@ export default function App() {
 
   const [singleName, setSingleName] = useState('')
   const [bulkNames, setBulkNames] = useState('')
+  const [genderToggleDisabledByPersonId, setGenderToggleDisabledByPersonId] = useState<Record<string, boolean>>({})
 
   const [fixedPersonIdDraft, setFixedPersonIdDraft] = useState('')
   const [fixedSeatDraft, setFixedSeatDraft] = useState('')
@@ -238,6 +239,11 @@ export default function App() {
     setRowsDraft(selectedProject.layout.rows)
     setColsDraft(selectedProject.layout.cols)
   }, [selectedProject])
+
+  useEffect(() => {
+    // プロジェクトを切り替えたら、性別トグルの disable 状態を初期化する。
+    setGenderToggleDisabledByPersonId({})
+  }, [selectedProjectId])
 
   useEffect(() => {
     if (!selectedAssignment) {
@@ -473,11 +479,12 @@ export default function App() {
 
   const handleToggleGender = useCallback(
     async (personId: string) => {
-      if (!selectedProject) {
+      if (!selectedProject || genderToggleDisabledByPersonId[personId]) {
         return
       }
 
       clearMessages()
+      setGenderToggleDisabledByPersonId((current) => ({ ...current, [personId]: true }))
       const nextPersons = selectedProject.persons.map((person) => {
         if (person.id !== personId) {
           return person
@@ -488,7 +495,7 @@ export default function App() {
 
       await saveProject({ ...selectedProject, persons: nextPersons })
     },
-    [clearMessages, saveProject, selectedProject],
+    [clearMessages, genderToggleDisabledByPersonId, saveProject, selectedProject],
   )
 
   const handleDeletePerson = useCallback(
@@ -1002,6 +1009,7 @@ export default function App() {
                                   person.gender === 'female' ? 'gender-toggle is-female' : 'gender-toggle is-male'
                                 }
                                 onClick={() => void handleToggleGender(person.id)}
+                                disabled={Boolean(genderToggleDisabledByPersonId[person.id])}
                                 aria-label={`${person.name} の性別を切り替え`}
                                 title={`クリックで ${formatGenderLabel(toggleGender(person.gender))} に切り替え`}
                               >


### PR DESCRIPTION
## 概要
Issue #10 の対応として、性別トグルの有効/無効を「2. レイアウト」セクションで切り替えられるように変更しました。

## 変更内容
- `src/App.tsx` に性別トグルの無効状態 `genderToggleDisabled` を追加
- 「2. レイアウト」に `男女切替` ボタンを追加し、`有効中/無効中` をトグル
- メンバー一覧の性別トグルボタンは `genderToggleDisabled` に連動して `disabled` を切替
- プロジェクト切替時に `genderToggleDisabled` を初期化

## 動作確認
- `npm run test -- --run`
- `npm run build`
- `npm run lint`

Closes #10


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a global control to enable/disable gender toggle actions (button shows current state: 男女切替: 無効中/有効中).  
  * Global disable resets automatically when switching projects.

* **Bug Fixes**
  * Per-person gender toggle buttons respect the global disabled state to prevent accidental or conflicting updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->